### PR TITLE
Use more common form of idiom

### DIFF
--- a/docs/ch10-effects/directed-particles.md
+++ b/docs/ch10-effects/directed-particles.md
@@ -65,7 +65,7 @@ The result is an arc going from the center-left to the bottom right.
 
 ![image](./assets/angledirection2.png)
 
-The values are discovered by try-and-error.
+The values are discovered by trial-and-error.
 
 Here is the full code of our emitter.
 


### PR DESCRIPTION
In the US, the accepted form of this phrase is "trial and error," not "try and error."