### PR TITLE
optimization demo

### DIFF
--- a/docs/ch04-qmlstart/src/positioners/ColumnExample.qml
+++ b/docs/ch04-qmlstart/src/positioners/ColumnExample.qml
@@ -39,7 +39,7 @@ DarkSquare {
     height: 240
 
     Column {
-        id: row
+        id: column
         anchors.centerIn: parent
         spacing: 8
         RedSquare { }


### PR DESCRIPTION
In the demo for Column,id should not "row".
I'm reading Qt QML Book,and from chapter Positioning Elements found it.