### PR TITLE
Fixes for image-viewer chapter

### DIFF
--- a/docs/ch06-controls/image-viewer.md
+++ b/docs/ch06-controls/image-viewer.md
@@ -98,15 +98,15 @@ ApplicationWindow {
     
     // ...
     
-    FileDialog {
+    Platform.FileDialog {
         id: fileOpenDialog
         title: "Select an image file"
-        folder: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+        folder: Platform.StandardPaths.writableLocation(Platform.StandardPaths.DocumentsLocation)
         nameFilters: [
             "Image files (*.png *.jpeg *.jpg)",
         ]
         onAccepted: {
-            image.source = fileOpenDialog.fileUrl
+            image.source = fileOpenDialog.file
         }
     }
 
@@ -163,6 +163,8 @@ ApplicationWindow {
     
     Dialog {
         id: aboutDialog
+        modal: true
+        anchors.centerIn: parent
         title: qsTr("About")
         Label {
             anchors.fill: parent
@@ -170,7 +172,7 @@ ApplicationWindow {
             horizontalAlignment: Text.AlignHCenter
         }
 
-        standardButtons: StandardButton.Ok
+        standardButtons: Platform.StandardButton.Ok
     }
 
     // ...


### PR DESCRIPTION
- Platform was not suffixed to elements belonging to to Qt.labs.platform, causing ReferenceError at runtime
- FileDialog's interface specifies that url is the correct member to be used to retrieve an image URL, current code causes error
- The image showing the about dialog doesn't match the code of the about dialog provided. Set modal to true and aligned center with the parent.