### PR TITLE
Minor grammatical corrections

### DIFF
--- a/docs/ch01-meetqt/blocks.md
+++ b/docs/ch01-meetqt/blocks.md
@@ -63,8 +63,8 @@ From the [Qt Wiki](http://wiki.qt.io/):
 
 The Qt Wiki is a place where Qt users and contributors share their insights. It forms the base for other users to contribute. The biggest contributor is The Qt Company, which holds also the commercial rights to Qt.
 
-Qt has an open-source aspect and a commercial aspect for companies. The commercial aspect is for companies which can not or will not comply with the open-source licenses. Without the commercial aspect, these companies would not be able to use Qt and it would not allow The Qt Company to contribute so much code to the Qt Project.
+Qt has an open-source aspect and a commercial aspect for companies. The commercial aspect is for companies which cannot or will not comply with the open-source licenses. Without the commercial aspect, these companies would not be able to use Qt and it would not allow The Qt Company to contribute so much code to the Qt Project.
 
-There are many companies worldwide, which make the living out of consultancy and product development using Qt on the various platforms. There are many open-source projects and open-source developers, which rely on Qt as their major development library. It feels good to be part of this vibrant community and to work with this awesome tools and libraries. Does it make you a better person? Maybe:-)
+There are many companies worldwide which make their living from consultancy and product development using Qt on various platforms. There are many open-source projects and open-source developers which rely on Qt as their major development library. It feels good to be part of this vibrant community and to work with these awesome tools and libraries. Does it make you a better person? Maybe:-)
 
 **Contribute here: http://wiki.qt.io/**


### PR DESCRIPTION
Made minor changes where minor grammatical errors distract from the content. 

For example, the usage of "can not" is a common mistake. The correct written form of "can't" is "cannot". "Can not" means there exists the option to not do something.