### PR TITLE
Update two sentences in intro.md

### DIFF
--- a/docs/ch01-meetqt/intro.md
+++ b/docs/ch01-meetqt/intro.md
@@ -10,7 +10,7 @@ Qt Quick is the umbrella term for the user interface technology used in Qt 6. It
 
 ![](./assets/qt6_overview.png)
 
-Similar to HTML, QML is a markup language. It is composed of tags, called types in Qt Quick, that are enclosed in curly brackets: `Item {}`. It was designed from the ground up for the creation of user interfaces, speed and easier reading for developers. The user interface can be enhanced further using JavaScript code. Qt Quick is easily extendable with your own native functionality using Qt C++. In short, the declarative UI is called the front-end and the native parts are called the back-end. This allows you to separate the computing intensive and native operation of your application from the user interface part.
+Similar to HTML, QML is a markup language. It is composed of tags, called types in Qt Quick, that are enclosed in curly brackets: `Item {}`. It was designed from the ground up for creating user interfaces, for speed, and for easier reading for developers. The user interface can be enhanced further using JavaScript code. Qt Quick is easily extendable with your own native functionality using Qt C++. In short, the declarative UI is called the front-end and the native parts are called the back-end. This allows you to separate the computing intensive and native operation of your application from the user interface part.
 
 In a typical project, the front-end is developed in QML/JavaScript. The back-end code, which interfaces with the system and does the heavy lifting, is developed using Qt C++. This allows a natural split between the more design-oriented developers and the functional developers. Typically, the back-end is tested using Qt Test, the Qt unit testing framework, and exported for the front-end developers to use.
 
@@ -74,7 +74,7 @@ Image {
 }
 ```
 
-To place the pinwheel in the middle, we use a complex property called `anchor`. Anchoring allows you to specify geometric relations between parent and sibling objects. For example, place me in the center of another type ( `anchors.centerIn: parent` ). There are left, right, top, bottom, centerIn, fill, verticalCenter and horizontalCenter relations on both ends. Naturally, when two or more anchors are used together, they should complement each other: it wouldn’t make sense, for instance, to anchor a type’s left side to the top of another type.
+To place the pinwheel in the middle, we use a complex property called `anchor`. Anchoring allows you to specify geometric relations between parent and sibling objects. For example, to place one item in the center of another: `anchors.centerIn: parent` ). There are left, right, top, bottom, centerIn, fill, verticalCenter and horizontalCenter relations on both ends. Naturally, when two or more anchors are used together, they should complement each other: it wouldn’t make sense, for instance, to anchor a type’s left side to the top of another type.
 
 For the pinwheel, the anchoring only requires one simple anchor.
 


### PR DESCRIPTION
The first edit adds "for" in front of each enumeration following "designed" because they are so different that the "for" helps make them consistent and clarifies that they are enumerations. The very first "for" is sandwiched between the verb-adverb "designed from the ground up" and "creating"... it could modify either one. "for creating [...], for speed, and for easier reading" is easier to understand than "for creating[...], speed, and easier reading" if the reader mistakenly associates "for" with "creating" instead of "designing". There are other ways to simplify the sentence, but this keeps the original intent IMO.

The second edit is more obvious: "For example, place me" doesn't fit with the writing style. Just below there is "For example, to nudge" so I modeled the change for the "place me" sentence after the "to nudge" sentence.